### PR TITLE
chore: use digest-based action references for security

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,10 +30,10 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # https://github.com/actions/checkout/tree/v5
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # https://github.com/docker/login-action/tree/v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -41,16 +41,16 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # https://github.com/docker/metadata-action/tree/v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # https://github.com/docker/setup-buildx-action/tree/v3
 
     - name: Build and push by digest
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # https://github.com/docker/build-push-action/tree/v6
       with:
         context: .
         platforms: ${{ matrix.platform }}
@@ -66,7 +66,7 @@ jobs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # https://github.com/actions/upload-artifact/tree/v4
       with:
         name: digests-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
@@ -83,25 +83,25 @@ jobs:
 
     steps:
     - name: Download digests
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # https://github.com/actions/download-artifact/tree/v4
       with:
         path: /tmp/digests
         pattern: digests-*
         merge-multiple: true
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # https://github.com/docker/login-action/tree/v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # https://github.com/docker/setup-buildx-action/tree/v3
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # https://github.com/docker/metadata-action/tree/v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # https://github.com/actions/checkout/tree/v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # https://github.com/actions/setup-node/tree/v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: npm run test:coverage
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # https://github.com/actions/upload-artifact/tree/v4
         with:
           name: coverage
           path: coverage/


### PR DESCRIPTION
## Summary
- Replace tag-based GitHub Action references with digest-based references
- Prevent potential tag overwrite attacks
- Improve workflow security

## Changes
- Updated all action references in `.github/workflows/main.yml`
- Updated all action references in `.github/workflows/docker-publish.yml`

## Security Improvement
This change mitigates the risk of tag overwrite attacks where malicious actors could potentially replace the code behind an action tag. By using commit SHA digests, we ensure that the exact version of the action code is used, regardless of any tag modifications.

## Test plan
- [x] Verify all workflows run successfully with the new digest-based references
- [x] Confirm that the digest values match the intended versions

🤖 Generated with [Claude Code](https://claude.ai/code)