### PR TITLE
ci: configure Dependabot for npm and GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+  groups:
+    artifact-actions:
+      patterns:
+        - "actions/upload-artifact"
+        - "actions/download-artifact"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "zod"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@types/node"
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency updates
- Configure npm packages with daily updates at 3:00 AM JST
- Configure GitHub Actions with daily updates and grouping for artifact actions

## Configuration Details
- **npm ecosystem**: Daily updates with timezone set to Asia/Tokyo, ignoring major updates for zod and @types/node
- **GitHub Actions**: Daily updates with grouped updates for artifact-related actions
- Open PR limit set to 10 for npm dependencies

## Test plan
- [x] Verify Dependabot configuration syntax is valid
- [ ] Confirm Dependabot will be activated after merge
- [ ] Monitor for first dependency update PRs after merge

🤖 Generated with [Claude Code](https://claude.ai/code)