### PR TITLE
chore: update version to 1.1.0 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppdiary",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ppdiary",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",


### PR DESCRIPTION
## Summary
- Update package-lock.json version from 1.0.3 to 1.1.0 to match package.json

## Context
This change was missed when the version was bumped to 1.1.0 in package.json.

🤖 Generated with [Claude Code](https://claude.ai/code)